### PR TITLE
Add return value check for _sodium_init()

### DIFF
--- a/dist/libsodium-wrappers.js
+++ b/dist/libsodium-wrappers.js
@@ -6,9 +6,9 @@
 
 	var output_format = "uint8array";
 
-    if (libsodium._sodium_init() !== 0) {
-        throw new Error("libsodium was not correctly initialized.");
-    }
+	if (libsodium._sodium_init() !== 0) {
+		throw new Error("libsodium was not correctly initialized.");
+	}
 
 	// List of functions and constants defined in the wrapped libsodium
 	function symbols() {

--- a/dist/libsodium-wrappers.js
+++ b/dist/libsodium-wrappers.js
@@ -6,7 +6,9 @@
 
 	var output_format = "uint8array";
 
-	libsodium._sodium_init();
+    if (libsodium._sodium_init() !== 0) {
+        throw new Error("libsodium was not correctly initialized.");
+    }
 
 	// List of functions and constants defined in the wrapped libsodium
 	function symbols() {


### PR DESCRIPTION
Hotfix following my merged PR in https://github.com/jedisct1/libsodium.js/pull/77.

---
libsodium requires proper initialization in order to behave securely (see core.c#L39).

libsodium.js should therefore verify that the return value of _sodium_init() is zero (e.g. like sodiumoxide does), and return an error otherwise.
